### PR TITLE
Add outbound Redis implementation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 generate:
 	# wit-bindgen c --export wit/ephemeral/spin-http.wit --out-dir ./src/native/
 	# wit-bindgen c --import wit/ephemeral/wasi-outbound-http.wit --out-dir ./src/native/
+	# wit-bindgen c --import wit/ephemeral/outbound-redis.wit --out-dir ./src/native
 
 .PHONY: bootstrap
 bootstrap:

--- a/samples/hello-world/spin.toml
+++ b/samples/hello-world/spin.toml
@@ -5,7 +5,9 @@ version = "1.0.0"
 
 [[component]]
 id = "hello"
-source = "bin/Debug/net7.0/HelloWorld.Spin.wasm"
+source = "bin/Release/net7.0/HelloWorld.Spin.wasm"
 allowed_http_hosts = [ "https://spin.fermyon.dev", "http://127.0.0.1:3001" ]
+[component.build]
+command = "dotnet build -c Release"
 [component.trigger]
 route = "/..."

--- a/src/Interop.cs
+++ b/src/Interop.cs
@@ -1,0 +1,83 @@
+using System.Runtime.InteropServices;
+using System.Text;
+
+[StructLayout(LayoutKind.Sequential)]
+public readonly struct Buffer
+{
+    private readonly nint _ptr;
+    private readonly int _length;
+
+    private Buffer(nint ptr, int length)
+    {
+        _ptr = ptr;
+        _length = length;
+    }
+
+    public unsafe ReadOnlySpan<byte> AsSpan() => new ReadOnlySpan<byte>((void*)_ptr, _length);
+
+    public static unsafe Buffer FromString(string value)
+    {
+        var interopString = InteropString.FromString(value);
+        return new Buffer(interopString._utf8Ptr, interopString._utf8Length);
+    }
+
+    public string ToUTF8String()
+    {
+        return Encoding.UTF8.GetString(this.AsSpan());
+    }
+
+    internal InteropString ToInteropString()
+        => new InteropString(_ptr, _length);
+}
+
+[StructLayout(LayoutKind.Sequential)]
+public readonly struct Optional<T>
+{
+    private readonly byte _isSome;
+    private readonly T _value;
+
+    internal Optional(T value)
+    {
+        _isSome = 1;
+        _value = value;
+    }
+
+    public bool TryGetValue(out T value)
+    {
+        value = _value;
+        return _isSome != 0;
+    }
+
+    public static readonly Optional<T> None = default;
+}
+
+public static class Optional
+{
+    // Just so the caller doesn't have to specify <T>
+    public static Optional<T> From<T>(T value) => new Optional<T>(value);
+}
+
+[StructLayout(LayoutKind.Sequential)]
+public readonly struct InteropString
+{
+    internal readonly nint _utf8Ptr;
+    internal readonly int _utf8Length;
+
+    internal InteropString(nint ptr, int length)
+    {
+        _utf8Ptr = ptr;
+        _utf8Length = length;
+    }
+
+    public override string ToString()
+        => Marshal.PtrToStringUTF8(_utf8Ptr, _utf8Length);
+
+    public static unsafe InteropString FromString(string value)
+    {
+        var exactByteCount = checked(Encoding.UTF8.GetByteCount(value));
+        var mem = Marshal.AllocHGlobal(exactByteCount);
+        var buffer = new Span<byte>((void*)mem, exactByteCount);
+        int byteCount = Encoding.UTF8.GetBytes(value, buffer);
+        return new InteropString(mem, byteCount);
+    }
+}

--- a/src/RedisInterop.cs
+++ b/src/RedisInterop.cs
@@ -1,0 +1,15 @@
+using System.Runtime.CompilerServices;
+
+namespace Fermyon.Spin.Sdk;
+
+internal static class OutboundRedisInterop
+{
+    [MethodImpl(MethodImplOptions.InternalCall)]
+    internal static extern unsafe byte outbound_redis_get(ref InteropString address, ref InteropString key, ref Buffer ret0);
+
+    [MethodImpl(MethodImplOptions.InternalCall)]
+    internal static extern unsafe byte outbound_redis_set(ref InteropString address, ref InteropString key, ref Buffer value);
+
+    [MethodImpl(MethodImplOptions.InternalCall)]
+    internal static extern unsafe byte outbound_redis_publish(ref InteropString address, ref InteropString channel, ref Buffer value);
+}

--- a/src/RedisOutbound.cs
+++ b/src/RedisOutbound.cs
@@ -1,0 +1,53 @@
+namespace Fermyon.Spin.Sdk;
+
+public static class RedisOutbound
+{
+    public static Buffer Get(string address, string key)
+    {
+        var res = new Buffer();
+        var redisAddress = InteropString.FromString(address);
+        var redisKey = InteropString.FromString(key);
+
+        var err = OutboundRedisInterop.outbound_redis_get(ref redisAddress, ref redisKey, ref res);
+        if (err == 0 || err == 255)
+        {
+            return res;
+        }
+        else
+        {
+            throw new Exception("Redis outbound error: cannot GET.");
+        }
+    }
+
+    public static void Set(string address, string key, Buffer payload)
+    {
+        var redisAddress = InteropString.FromString(address);
+        var redisKey = InteropString.FromString(key);
+
+        var err = OutboundRedisInterop.outbound_redis_set(ref redisAddress, ref redisKey, ref payload);
+        if (err == 0 || err == 255)
+        {
+            return;
+        }
+        else
+        {
+            throw new Exception("Redis outbound error: cannot SET.");
+        }
+    }
+
+    public static void Publish(string address, string channel, Buffer payload)
+    {
+        var redisAddress = InteropString.FromString(address);
+        var redisChannel = InteropString.FromString(channel);
+
+        var err = OutboundRedisInterop.outbound_redis_publish(ref redisAddress, ref redisChannel, ref payload);
+        if (err == 0 || err == 255)
+        {
+            return;
+        }
+        else
+        {
+            throw new Exception("Redis outbound error: cannot PUBLISH.");
+        }
+    }
+}

--- a/src/build/Fermyon.Spin.Sdk.targets
+++ b/src/build/Fermyon.Spin.Sdk.targets
@@ -6,6 +6,7 @@
 		<WasiNativeFileReference Include="$(MSBuildThisFileDirectory)..\native\util.c" />
 		<WasiNativeFileReference Include="$(MSBuildThisFileDirectory)..\native\spin-http.c" />
 		<WasiNativeFileReference Include="$(MSBuildThisFileDirectory)..\native\wasi-outbound-http.c" />
+		<WasiNativeFileReference Include="$(MSBuildThisFileDirectory)..\native\outbound-redis.c" />
 		<WasiAfterRuntimeLoaded Include="spin_attach_internal_calls" />
 	</ItemGroup>
 

--- a/src/native/host-components.c
+++ b/src/native/host-components.c
@@ -13,8 +13,13 @@
 
 #include "host-components.h"
 #include "wasi-outbound-http.h"
+#include "outbound-redis.h"
 
 void spin_attach_internal_calls()
 {
     mono_add_internal_call("Fermyon.Spin.Sdk.OutboundHttpInterop::wasi_outbound_http_request", wasi_outbound_http_request);
+
+    mono_add_internal_call("Fermyon.Spin.Sdk.OutboundRedisInterop::outbound_redis_get", outbound_redis_get);
+    mono_add_internal_call("Fermyon.Spin.Sdk.OutboundRedisInterop::outbound_redis_set", outbound_redis_set);
+    mono_add_internal_call("Fermyon.Spin.Sdk.OutboundRedisInterop::outbound_redis_publish", outbound_redis_publish);
 }

--- a/src/native/outbound-redis.c
+++ b/src/native/outbound-redis.c
@@ -1,0 +1,140 @@
+#include <stdlib.h>
+#include "outbound-redis.h"
+
+__attribute__((weak, export_name("canonical_abi_realloc"))) void *canonical_abi_realloc(
+    void *ptr,
+    size_t orig_size,
+    size_t org_align,
+    size_t new_size)
+{
+  void *ret = realloc(ptr, new_size);
+  if (!ret)
+    abort();
+  return ret;
+}
+
+__attribute__((weak, export_name("canonical_abi_free"))) void canonical_abi_free(
+    void *ptr,
+    size_t size,
+    size_t align)
+{
+  free(ptr);
+}
+#include <string.h>
+
+void outbound_redis_string_set(outbound_redis_string_t *ret, const char *s)
+{
+  ret->ptr = (char *)s;
+  ret->len = strlen(s);
+}
+
+void outbound_redis_string_dup(outbound_redis_string_t *ret, const char *s)
+{
+  ret->len = strlen(s);
+  ret->ptr = canonical_abi_realloc(NULL, 0, 1, ret->len);
+  memcpy(ret->ptr, s, ret->len);
+}
+
+void outbound_redis_string_free(outbound_redis_string_t *ret)
+{
+  canonical_abi_free(ret->ptr, ret->len, 1);
+  ret->ptr = NULL;
+  ret->len = 0;
+}
+void outbound_redis_payload_free(outbound_redis_payload_t *ptr)
+{
+  canonical_abi_free(ptr->ptr, ptr->len * 1, 1);
+}
+typedef struct
+{
+  bool is_err;
+  union
+  {
+    outbound_redis_error_t err;
+  } val;
+} outbound_redis_expected_unit_error_t;
+typedef struct
+{
+  bool is_err;
+  union
+  {
+    outbound_redis_payload_t ok;
+    outbound_redis_error_t err;
+  } val;
+} outbound_redis_expected_payload_error_t;
+
+__attribute__((aligned(4))) static uint8_t RET_AREA[12];
+__attribute__((import_module("outbound-redis"), import_name("publish"))) void __wasm_import_outbound_redis_publish(int32_t, int32_t, int32_t, int32_t, int32_t, int32_t, int32_t);
+outbound_redis_error_t outbound_redis_publish(outbound_redis_string_t *address, outbound_redis_string_t *channel, outbound_redis_payload_t *payload)
+{
+  int32_t ptr = (int32_t)&RET_AREA;
+  __wasm_import_outbound_redis_publish((int32_t)(*address).ptr, (int32_t)(*address).len, (int32_t)(*channel).ptr, (int32_t)(*channel).len, (int32_t)(*payload).ptr, (int32_t)(*payload).len, ptr);
+  outbound_redis_expected_unit_error_t expected;
+  switch ((int32_t)(*((uint8_t *)(ptr + 0))))
+  {
+  case 0:
+  {
+    expected.is_err = false;
+
+    break;
+  }
+  case 1:
+  {
+    expected.is_err = true;
+
+    expected.val.err = (int32_t)(*((uint8_t *)(ptr + 1)));
+    break;
+  }
+  }
+  return expected.is_err ? expected.val.err : -1;
+}
+__attribute__((import_module("outbound-redis"), import_name("get"))) void __wasm_import_outbound_redis_get(int32_t, int32_t, int32_t, int32_t, int32_t);
+outbound_redis_error_t outbound_redis_get(outbound_redis_string_t *address, outbound_redis_string_t *key, outbound_redis_payload_t *ret0)
+{
+  int32_t ptr = (int32_t)&RET_AREA;
+  __wasm_import_outbound_redis_get((int32_t)(*address).ptr, (int32_t)(*address).len, (int32_t)(*key).ptr, (int32_t)(*key).len, ptr);
+  outbound_redis_expected_payload_error_t expected;
+  switch ((int32_t)(*((uint8_t *)(ptr + 0))))
+  {
+  case 0:
+  {
+    expected.is_err = false;
+
+    expected.val.ok = (outbound_redis_payload_t){(uint8_t *)(*((int32_t *)(ptr + 4))), (size_t)(*((int32_t *)(ptr + 8)))};
+    break;
+  }
+  case 1:
+  {
+    expected.is_err = true;
+
+    expected.val.err = (int32_t)(*((uint8_t *)(ptr + 4)));
+    break;
+  }
+  }
+  *ret0 = expected.val.ok;
+  return expected.is_err ? expected.val.err : -1;
+}
+__attribute__((import_module("outbound-redis"), import_name("set"))) void __wasm_import_outbound_redis_set(int32_t, int32_t, int32_t, int32_t, int32_t, int32_t, int32_t);
+outbound_redis_error_t outbound_redis_set(outbound_redis_string_t *address, outbound_redis_string_t *key, outbound_redis_payload_t *value)
+{
+  int32_t ptr = (int32_t)&RET_AREA;
+  __wasm_import_outbound_redis_set((int32_t)(*address).ptr, (int32_t)(*address).len, (int32_t)(*key).ptr, (int32_t)(*key).len, (int32_t)(*value).ptr, (int32_t)(*value).len, ptr);
+  outbound_redis_expected_unit_error_t expected;
+  switch ((int32_t)(*((uint8_t *)(ptr + 0))))
+  {
+  case 0:
+  {
+    expected.is_err = false;
+
+    break;
+  }
+  case 1:
+  {
+    expected.is_err = true;
+
+    expected.val.err = (int32_t)(*((uint8_t *)(ptr + 1)));
+    break;
+  }
+  }
+  return expected.is_err ? expected.val.err : -1;
+}

--- a/src/native/outbound-redis.h
+++ b/src/native/outbound-redis.h
@@ -1,0 +1,33 @@
+#ifndef __BINDINGS_OUTBOUND_REDIS_H
+#define __BINDINGS_OUTBOUND_REDIS_H
+#ifdef __cplusplus
+extern "C"
+{
+  #endif
+  
+  #include <stdint.h>
+  #include <stdbool.h>
+  
+  typedef struct {
+    char *ptr;
+    size_t len;
+  } outbound_redis_string_t;
+  
+  void outbound_redis_string_set(outbound_redis_string_t *ret, const char *s);
+  void outbound_redis_string_dup(outbound_redis_string_t *ret, const char *s);
+  void outbound_redis_string_free(outbound_redis_string_t *ret);
+  typedef uint8_t outbound_redis_error_t;
+  #define OUTBOUND_REDIS_ERROR_SUCCESS 0
+  #define OUTBOUND_REDIS_ERROR_ERROR 1
+  typedef struct {
+    uint8_t *ptr;
+    size_t len;
+  } outbound_redis_payload_t;
+  void outbound_redis_payload_free(outbound_redis_payload_t *ptr);
+  outbound_redis_error_t outbound_redis_publish(outbound_redis_string_t *address, outbound_redis_string_t *channel, outbound_redis_payload_t *payload);
+  outbound_redis_error_t outbound_redis_get(outbound_redis_string_t *address, outbound_redis_string_t *key, outbound_redis_payload_t *ret0);
+  outbound_redis_error_t outbound_redis_set(outbound_redis_string_t *address, outbound_redis_string_t *key, outbound_redis_payload_t *value);
+  #ifdef __cplusplus
+}
+#endif
+#endif

--- a/wit/ephemeral/outbound-redis.wit
+++ b/wit/ephemeral/outbound-redis.wit
@@ -1,0 +1,10 @@
+use * from redis-types
+
+// Publish a Redis message to the specified channel and return an error, if any.
+publish: func(address: string, channel: string, payload: payload) -> expected<unit, error>
+
+// Get the value of a key.
+get: func(address: string, key: string) -> expected<payload, error>
+
+// Set key to value. If key already holds a value, it is overwritten.
+set: func(address: string, key: string, value: payload) -> expected<unit, error>

--- a/wit/ephemeral/redis-types.wit
+++ b/wit/ephemeral/redis-types.wit
@@ -1,0 +1,8 @@
+// General purpose error.
+enum error {
+    success,
+    error,
+}
+
+// The message payload.
+type payload = list<u8>


### PR DESCRIPTION
This commit adds support for performing outbound HTTP requests in the SDK.
Specifically:

* it adds the Spin WIT files for outbound Redis
* it adds (a commented out) Make target to generate the bindings
(currently, the steps to re-generate the bindings are all commented in
the Makefile because we need to update the import paths to include the
directory where we generate the headers).
* it extracts a few common types in `Interop.cs`, which now contains
general `InteropString` and `Buffer` types that represent the WIT `string`
and `list<u8>` types — this means that any WIT files that uses those
two (relatively common) types can be represented in this SDK using the
new types.
* it implements the Redis GET, SET, and PUBLISH functions as exposed by
the Spin host component.
* it adds an example in `Handler.cs`, `/redis`, which uses the three
new functions added.

Signed-off-by: Radu Matei <radu.matei@fermyon.com>