### PR TITLE
Update instructions to use 'spin build'

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -11,8 +11,7 @@ Then, build and run the `hello-world` sample:
 
 ```
 $ cd samples/hello-world
-$ dotnet build
-$ spin up
+$ spin build && spin up --follow-all
 ```
 
 If everything worked, you should see a Spin "serving routes" message:


### PR DESCRIPTION
Dotnet build puts the build output in the /Debug folder, so this doesn't match the spin.toml configuration.
Also proposing to use --follow-all.

Signed-off-by: Mikkel Mork Hegnhoj <mikkel@fermyon.com>