### PR TITLE
Option to skip the warmup request during wizerisation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -135,5 +135,7 @@ Using Wizer has certain observable impacts:
   number generator_ will be used in all requests!
 
 You can identify if a request is the warmup request because the URL will be `/warmupz`.
-You can override this in the `HttpHandler` attribute.  However, it is not currently possible
-to have Wizer initialise the runtime but omit calling your handler.
+You can override this in the `HttpHandler` attribute.  If you want to have partial warmup
+but not have to process a warmup request, you can set `SendWarmupRequest = false` on the
+attribute; however, this is nowhere near as effective as full warmup in reducing startup
+times.

--- a/src/HttpInterop.cs
+++ b/src/HttpInterop.cs
@@ -149,6 +149,19 @@ public struct HttpRequest
         get => _body;
         set => _body = value;
     }
+
+    // This is called instead of the user code if HttpHandlerAttribute.SendWarmupRequest is
+    // false.  It doesn't provide as much speedup as if we are allowed to call the user
+    // code, but it does exercise enough paths in the SDK to make some improvement.
+    private static HttpResponse DoSdkWarmup(HttpRequest r)
+    {
+        return new HttpResponse
+        {
+            StatusCode = HttpStatusCode.OK,
+            Headers = new Dictionary<string, string>(),
+            BodyAsString = "WARMUP TIME\n",
+        };
+    }
 }
 
 /// <summary>

--- a/src/HttpTrigger.cs
+++ b/src/HttpTrigger.cs
@@ -7,6 +7,15 @@ namespace Fermyon.Spin.Sdk;
 public sealed class HttpHandlerAttribute : Attribute
 {
     /// <summary>
+    /// Gets or sets whether to send a warmup request during build. The default is true.
+    /// The warmup request preloads and prepares the request handler code, meaning the load code does
+    /// not have to run on every request.  If false, warmup code is run for the .NET runtime
+    /// and Spin SDK, but not the request handler; this results in an increased startup cost for
+    /// every request at runtime.
+    /// </summary>
+    public bool SendWarmupRequest { get; set; } = true;
+
+    /// <summary>
     /// Gets or sets the URL passed to the HTTP handler to indicate that the request is occurring during warmup.
     /// The default is Warmup.DefaultWarmupUrl.
     /// </summary>


### PR DESCRIPTION
By setting `[HttpHandler(SendWarmupRequest = false)]`, an author can have their module wizerised but _not_ have to process a request at build time.  This is done to evaluate what we can offer to an author who doesn't want to write special handling for a warmup URL, but doesn't want to give up the benefits of wizerisation entirely.

This PR is offered tentatively, and I remain undecided whether we should do it - it felt weird saying "you have to either handle the special request or give up Wizer altogether," so I wanted to get some numbers as to whether the middle ground was worthwhile.  The performance for the echo handler on my machine is roughly:

* Full warmup: 0.2ms
* Wizer but no warmup request: 17-20ms
* No wizer: 60-65ms

but these are very crude measures...

Signed-off-by: itowlson <ivan.towlson@fermyon.com>