### PR TITLE
Removed Parameters property and switched over sample

### DIFF
--- a/samples/hello-world/Handler.cs
+++ b/samples/hello-world/Handler.cs
@@ -64,9 +64,11 @@ public static class Handler
             responseText.AppendLine($"Header '{h.Key}' had value '{h.Value}'");
         }
 
-        foreach (var p in request.Parameters)
+        var uri = new System.Uri(request.Headers["spin-full-url"]);
+        var queryParameters = System.Web.HttpUtility.ParseQueryString(uri.Query);
+        foreach (var key in queryParameters.AllKeys)
         {
-            responseText.AppendLine($"Parameter '{p.Key}' had value '{p.Value}'");
+            responseText.AppendLine($"Parameter '{key}' had value '{queryParameters[key]}'");
         }
 
         var bodyInfo = request.Body.HasContent() ?
@@ -101,14 +103,11 @@ public static class Handler
             responseText.AppendLine($"Header '{h.Key}' had value '{h.Value}'");
         }
 
-        if (request.Parameters.Count == 0)
+        var uri = new System.Uri(request.Headers["spin-full-url"]);
+        var queryParameters = System.Web.HttpUtility.ParseQueryString(uri.Query);
+        foreach (var key in queryParameters.AllKeys)
         {
-            responseText.AppendLine($"Cripes!  There were no query args");
-        }
-
-        foreach (var p in request.Parameters)
-        {
-            responseText.AppendLine($"Parameter '{p.Key}' had value '{p.Value}'");
+            responseText.AppendLine($"Parameter '{key}' had value '{queryParameters[key]}'");
         }
 
         var bodyInfo = request.Body.HasContent() ?

--- a/src/HttpInterop.cs
+++ b/src/HttpInterop.cs
@@ -102,7 +102,7 @@ public struct HttpRequest
     private HttpMethod _method;
     private InteropString _url;
     private HttpKeyValues _headers;
-    private HttpKeyValues _parameters;
+    private HttpKeyValues _parameters_unused;
     private Optional<Buffer> _body;
 
     /// <summary>
@@ -130,14 +130,6 @@ public struct HttpRequest
     {
         get => _headers;
         set => _headers = HttpKeyValues.FromDictionary(value);
-    }
-
-    /// <summary>
-    /// Gets the request query parameters.
-    /// </summary>
-    public IReadOnlyDictionary<string, string> Parameters
-    {
-        get => _parameters;
     }
 
     /// <summary>


### PR DESCRIPTION
As part of deprecating the parameters field, this removes the Parameters accessor from the HttpRequest struct, and provides a sample of parsing the query string using native .NET facilities.

This is something we could promote to library behaviour as we get a better handle on how to align with .NET's modern Web stacks.

Signed-off-by: itowlson <ivan.towlson@fermyon.com>