### PR TITLE
update template to use NuGet package for SDK

### DIFF
--- a/templates/http-csharp/content/Project.csproj
+++ b/templates/http-csharp/content/Project.csproj
@@ -1,14 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="{{sdk-path}}/src/build/Fermyon.Spin.Sdk.props" />
-  <Import Project="{{sdk-path}}/src/build/Fermyon.Spin.Sdk.targets" />
-
   <ItemGroup>
     <PackageReference Include="Wasi.Sdk" Version="0.1.1" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="{{sdk-path}}/src/Fermyon.Spin.Sdk.csproj" />
+    <PackageReference Include="Fermyon.Spin.Sdk" Version="0.1.0-alpha" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/templates/http-csharp/metadata/spin-template.toml
+++ b/templates/http-csharp/metadata/spin-template.toml
@@ -3,7 +3,6 @@ id = "http-csharp"
 description = "HTTP request handler using C# (EXPERIMENTAL)"
 
 [parameters]
-sdk-path = { type = "string",  prompt = "Path to the Spin .NET SDK Git repo (relative to output directory)" }
 project-description = { type = "string",  prompt = "Project description" }
 http-base = { type = "string", prompt = "HTTP base", default = "/", pattern = "^/\\S*$" }
 http-path = { type = "string", prompt = "HTTP path", default = "/...", pattern = "^/\\S*$" }


### PR DESCRIPTION
Signed-off-by: Mikkel Mørk Hegnhøj <mikkel@fermyon.com>

Fixes: #31 

Testes locally with the template to be able to do:

```
spin new http-csharp
spin build && spin-up
curl http://localhost:3000
```