### PR TITLE
update to latest Wasi.Sdk and latest Wizer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,4 +10,4 @@ generate:
 bootstrap:
 	# install the WIT Bindgen version we are currently using in Spin e06c6b1
 	cargo install wit-bindgen-cli --git https://github.com/bytecodealliance/wit-bindgen --rev dde4694aaa6acf9370206527a798ac4ba6a8c5b8 --force
-	cargo install wizer --all-features
+	cargo install --git https://github.com/bytecodealliance/wizer --rev 65e345fb2bd5b5177d4be55af747edc28035c35c --all-features wizer

--- a/samples/hello-world/HelloWorld.Spin.csproj
+++ b/samples/hello-world/HelloWorld.Spin.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Wasi.Sdk" Version="0.1.1" />
+    <PackageReference Include="Wasi.Sdk" Version="0.1.2-preview.10061" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/build/Fermyon.Spin.Sdk.targets
+++ b/src/build/Fermyon.Spin.Sdk.targets
@@ -16,7 +16,7 @@
 	<!-- Consider baking wizer into spin itself so that it can generate its own preinitialized version of the .wasm modules during startup -->
 	<Target Name="RunWizer" AfterTargets="CopyWasmToOutput" Condition="$(UseWizer) == 'true'">
 		<Message Importance="high" Text="Running wizer to preinitialize @(WasiSdkBinOutputFiles)..." />
-		<Exec Command="wizer @(WasiSdkBinOutputFiles) -o @(WasiSdkBinOutputFiles).pre.wasm --allow-wasi" />
+		<Exec Command="wizer @(WasiSdkBinOutputFiles) -o @(WasiSdkBinOutputFiles).pre.wasm --allow-wasi --wasm-bulk-memory true" />
 		<Delete Files="@(WasiSdkBinOutputFiles)" />
 		<Move SourceFiles="@(WasiSdkBinOutputFiles->'%(Identity).pre.wasm')" DestinationFiles="@(WasiSdkBinOutputFiles)" />
 	</Target>


### PR DESCRIPTION
Wizer now has partial support for bulk memory operations, which allows us to use
the latest Wasi.Sdk and enjoy the benefits of reduced memory usage (50MB
vs. 500MB).

Signed-off-by: Joel Dice <joel.dice@fermyon.com>