### PR TITLE
Ensure source in spin.toml and AssemblyName in Project.csproj match

### DIFF
--- a/templates/http-csharp/content/spin.toml
+++ b/templates/http-csharp/content/spin.toml
@@ -7,7 +7,7 @@ trigger = { type = "http", base = "{{http-base}}" }
 
 [[component]]
 id = "{{project-name | snake_case}}"
-source = "bin/Release/net7.0/{{project-name}}.wasm"
+source = "bin/Release/net7.0/{{project-name | dotted_pascal_case}}.wasm"
 [component.build]
 command = "dotnet build -c Release"
 [component.trigger]


### PR DESCRIPTION
This will fix an issue when users create a project name using a "pascal-dotted-case" format. 

Example:

```
spin new http-csharp my-spin-demo
```

When this happens, the actual dotnet AssemblyName will be set to `MySpinDemo` but in the spin.toml file, the source will be set to `bin/Release/net7.0/my-spin-demo.wasm`.  

As a result, the `spin up` command will return the following error:

```
Error: failed to resolve content at "/Users/paul/repos/fermyon/my-spin-demo/bin/Release/net7.0/my-spin-demo.wasm"

Caused by:
    No such file or directory (os error 2)
```