### PR TITLE
Wasi.Sdk upgrade to 0.1.3-preview.10012

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,6 @@ generate:
 
 .PHONY: bootstrap
 bootstrap:
-	# install the WIT Bindgen version we are currently using in Spin e06c6b1
-	cargo install wit-bindgen-cli --git https://github.com/bytecodealliance/wit-bindgen --rev dde4694aaa6acf9370206527a798ac4ba6a8c5b8 --force
-	cargo install wizer --all-features
+	# install the WIT Bindgen version we are currently using in Spin v0.7.1
+	cargo install wit-bindgen-cli --git https://github.com/bytecodealliance/wit-bindgen --rev cb871cfa1ee460b51eb1d144b175b9aab9c50aba --force
+	cargo install wizer --git https://github.com/bytecodealliance/wizer --rev 04e49c989542f2bf3a112d60fbf88a62cce2d0d0 --all-features --force

--- a/samples/Fermyon.PetStore/Fermyon.PetStore.Home/Project.csproj
+++ b/samples/Fermyon.PetStore/Fermyon.PetStore.Home/Project.csproj
@@ -4,7 +4,7 @@
   <Import Project="../../../src/build/Fermyon.Spin.Sdk.targets" />
 
   <ItemGroup>
-    <PackageReference Include="Wasi.Sdk" Version="0.1.1" />
+    <PackageReference Include="Wasi.Sdk" Version="0.1.3-preview.10012" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Fermyon.PetStore/Fermyon.PetStore.NewPet/Project.csproj
+++ b/samples/Fermyon.PetStore/Fermyon.PetStore.NewPet/Project.csproj
@@ -8,7 +8,7 @@
 	</ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Wasi.Sdk" Version="0.1.1" />
+    <PackageReference Include="Wasi.Sdk" Version="0.1.3-preview.10012" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Fermyon.PetStore/Fermyon.PetStore.NewToy/Project.csproj
+++ b/samples/Fermyon.PetStore/Fermyon.PetStore.NewToy/Project.csproj
@@ -8,7 +8,7 @@
 	</ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Wasi.Sdk" Version="0.1.1" />
+    <PackageReference Include="Wasi.Sdk" Version="0.1.3-preview.10012" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Fermyon.PetStore/Fermyon.PetStore.Pet/Project.csproj
+++ b/samples/Fermyon.PetStore/Fermyon.PetStore.Pet/Project.csproj
@@ -4,7 +4,7 @@
   <Import Project="../../../src/build/Fermyon.Spin.Sdk.targets" />
 
   <ItemGroup>
-    <PackageReference Include="Wasi.Sdk" Version="0.1.1" />
+    <PackageReference Include="Wasi.Sdk" Version="0.1.3-preview.10012" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Fermyon.PetStore/Fermyon.PetStore.Pets/Project.csproj
+++ b/samples/Fermyon.PetStore/Fermyon.PetStore.Pets/Project.csproj
@@ -4,7 +4,7 @@
   <Import Project="../../../src/build/Fermyon.Spin.Sdk.targets" />
 
   <ItemGroup>
-    <PackageReference Include="Wasi.Sdk" Version="0.1.1" />
+    <PackageReference Include="Wasi.Sdk" Version="0.1.3-preview.10012" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Fermyon.PetStore/Fermyon.PetStore.Toy/Project.csproj
+++ b/samples/Fermyon.PetStore/Fermyon.PetStore.Toy/Project.csproj
@@ -4,7 +4,7 @@
   <Import Project="../../../src/build/Fermyon.Spin.Sdk.targets" />
 
   <ItemGroup>
-    <PackageReference Include="Wasi.Sdk" Version="0.1.1" />
+    <PackageReference Include="Wasi.Sdk" Version="0.1.3-preview.10012" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Fermyon.PetStore/Fermyon.PetStore.Toys/Project.csproj
+++ b/samples/Fermyon.PetStore/Fermyon.PetStore.Toys/Project.csproj
@@ -4,7 +4,7 @@
   <Import Project="../../../src/build/Fermyon.Spin.Sdk.targets" />
 
   <ItemGroup>
-    <PackageReference Include="Wasi.Sdk" Version="0.1.1" />
+    <PackageReference Include="Wasi.Sdk" Version="0.1.3-preview.10012" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/hello-world/Handler.cs
+++ b/samples/hello-world/Handler.cs
@@ -103,12 +103,13 @@ public static class Handler
             responseText.AppendLine($"Header '{h.Key}' had value '{h.Value}'");
         }
 
-        var uri = new System.Uri(request.Headers["spin-full-url"]);
-        var queryParameters = System.Web.HttpUtility.ParseQueryString(uri.Query);
-        foreach (var key in queryParameters.AllKeys)
-        {
-            responseText.AppendLine($"Parameter '{key}' had value '{queryParameters[key]}'");
-        }
+        // commenting this section out because headers are empty when wizer-ing
+        // var uri = new System.Uri(request.Headers["spin-full-url"]);
+        // var queryParameters = System.Web.HttpUtility.ParseQueryString(uri.Query);
+        // foreach (var key in queryParameters.AllKeys)
+        // {
+        //     responseText.AppendLine($"Parameter '{key}' had value '{queryParameters[key]}'");
+        // }
 
         var bodyInfo = request.Body.HasContent() ?
             $"The body (as a string) was: {request.Body.AsString()}\n" :

--- a/samples/hello-world/HelloWorld.Spin.csproj
+++ b/samples/hello-world/HelloWorld.Spin.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Wasi.Sdk" Version="0.1.1" />
+    <PackageReference Include="Wasi.Sdk" Version="0.1.3-preview.10012" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Fermyon.Spin.Sdk.csproj
+++ b/src/Fermyon.Spin.Sdk.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <!-- TODO: There should be some way to indicate "this is a class library so don't build a .wasm binary" even when referencing this SDK -->
-    <PackageReference Include="Wasi.Sdk" Version="0.1.1" />
+    <PackageReference Include="Wasi.Sdk" Version="0.1.3-preview.10012" />
   </ItemGroup>
 
 	<Target Name="PackTaskDependencies" BeforeTargets="GenerateNuspec">

--- a/src/build/Fermyon.Spin.Sdk.targets
+++ b/src/build/Fermyon.Spin.Sdk.targets
@@ -16,7 +16,7 @@
 	<!-- Consider baking wizer into spin itself so that it can generate its own preinitialized version of the .wasm modules during startup -->
 	<Target Name="RunWizer" AfterTargets="CopyWasmToOutput" Condition="$(UseWizer) == 'true'">
 		<Message Importance="high" Text="Running wizer to preinitialize @(WasiSdkBinOutputFiles)..." />
-		<Exec Command="wizer @(WasiSdkBinOutputFiles) -o @(WasiSdkBinOutputFiles).pre.wasm --allow-wasi" />
+		<Exec Command="wizer @(WasiSdkBinOutputFiles) -o @(WasiSdkBinOutputFiles).pre.wasm --allow-wasi --wasm-bulk-memory true" />
 		<Delete Files="@(WasiSdkBinOutputFiles)" />
 		<Move SourceFiles="@(WasiSdkBinOutputFiles->'%(Identity).pre.wasm')" DestinationFiles="@(WasiSdkBinOutputFiles)" />
 	</Target>

--- a/templates/http-csharp/content/Project.csproj
+++ b/templates/http-csharp/content/Project.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <PackageReference Include="Wasi.Sdk" Version="0.1.1" />
+    <PackageReference Include="Wasi.Sdk" Version="0.1.3-preview.10012" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This set of changes upgrades Wasi.Sdk dependency version to be `0.1.3-preview.10012`. It also upgrades wit-bindgen version in `make bootstrap` to match what is currently used in the Spin v0.7.1 SDK. Additionally I upgraded wizer to the latest commit on main. I'm not sure if the wizer / wit-bindgen versions are correct, I just grabbed the latest revisions.

Additionally it comments out a section of code that is failing to initialize with wizer because the expected header isn't present.