### PR TITLE
chore(*): migrate samples/templates to Spin manifest v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ obj/
 .suo
 .vs/
 !templates/**/filters/*.wasm
+**/.spin

--- a/readme.md
+++ b/readme.md
@@ -30,7 +30,7 @@ To build and run the `hello-world` sample, clone this repo and run:
 
 ```
 $ cd samples/hello-world
-$ spin build && spin up --follow-all
+$ spin build --up
 ```
 
 If everything worked, you should see a Spin "serving routes" message:
@@ -67,7 +67,7 @@ The SDK includes a Spin template for C# projects.  To install it, run:
 spin templates install --git https://github.com/fermyon/spin-dotnet-sdk --branch main --update
 ```
 
-You can then run `spin new http-csharp <project-name>` to create a new Spin C# application.
+You can then run `spin new -t http-csharp <project-name>` to create a new Spin C# application.
 
 > If you're creating a project without using the Spin template, add a reference the Spin SDK with the command
 > `dotnet add package Fermyon.Spin.Sdk --prerelease`
@@ -94,11 +94,8 @@ public static class MyHandler
 Your `spin.toml` file should reference the compiled Wasm file built from the project.
 
 ```toml
-[[component]]
-id = "test"
+[component.test]
 source = "bin/Release/net8.0/MyApplication.wasm"
-[component.trigger]
-route = "/..."
 ```
 
 ### Making outbound HTTP requests

--- a/samples/Fermyon.PetStore/README.md
+++ b/samples/Fermyon.PetStore/README.md
@@ -6,7 +6,7 @@ application using Spin and PostgreSQL.
 If you want to run this sample, you'll need to:
 
 1. Set up a PostgreSQL database using the tables in the `sql` directory.
-1. Set the `SPIN_CONFIG_PG_CONN_STR` environment variable to the connection string for the database.
+1. Set the `SPIN_VARIABLE_PG_CONN_STR` environment variable to the connection string for the database.
    The connection string is in space-separated format e.g. `user=foo password=bar dbname=test host=127.0.0.1`
 
 We will provide more detailed information in a subsequent update. In the

--- a/samples/Fermyon.PetStore/spin.toml
+++ b/samples/Fermyon.PetStore/spin.toml
@@ -1,91 +1,106 @@
-spin_manifest_version = "1"
+spin_manifest_version = 2
+
+[application]
 authors = ["itowlson <ivan.towlson@fermyon.com>"]
 description = "Where pets store their toys!"
 name = "Fermyon.PetStore"
 version = "1.0.0"
-trigger = { type = "http", base = "/" }
 
-[variables]
-pg_conn_str = { required = true }
+[variables.pg_conn_str]
+required = true
 
-[[component]]
-id = "home"
+[[trigger.http]]
+route = "/"
+component = "home"
+
+[component.home]
 source = "Fermyon.PetStore.Home/bin/Release/net8.0/Fermyon.PetStore.Home.wasm"
 files = [{ source = "Fermyon.PetStore.Home/assets", destination = "/assets" }]
-[component.build]
+allowed_outbound_hosts = ["http://localhost:3000", "postgres://localhost:5432"]
+[component.home.build]
 command = "dotnet build -c Release"
 workdir = "Fermyon.PetStore.Home"
-[component.trigger]
-route = "/"
 
-[[component]]
-id = "pets"
+[[trigger.http]]
+route = "/pets"
+component = "pets"
+
+[component.pets]
 source = "Fermyon.PetStore.Pets/bin/Release/net8.0/Fermyon.PetStore.Pets.wasm"
 files = [{ source = "Fermyon.PetStore.Pets/assets", destination = "/assets" }]
-[component.config]
+allowed_outbound_hosts = ["http://localhost:3000", "postgres://localhost:5432"]
+[component.pets.variables]
 pg_conn_str = "{{ pg_conn_str }}"
-[component.build]
+[component.pets.build]
 command = "dotnet build -c Release"
 workdir = "Fermyon.PetStore.Pets"
-[component.trigger]
-route = "/pets"
 
-[[component]]
-id = "new_pet"
+[[trigger.http]]
+route = "/pets/new"
+component = "new-pet"
+
+[component.new-pet]
 source = "Fermyon.PetStore.NewPet/bin/Release/net8.0/Fermyon.PetStore.NewPet.wasm"
 files = [{ source = "Fermyon.PetStore.NewPet/assets", destination = "/assets" }]
-[component.config]
+allowed_outbound_hosts = ["http://localhost:3000", "postgres://localhost:5432"]
+[component.new-pet.variables]
 pg_conn_str = "{{ pg_conn_str }}"
-[component.build]
+[component.new-pet.build]
 command = "dotnet build -c Release"
 workdir = "Fermyon.PetStore.NewPet"
-[component.trigger]
-route = "/pets/new"
 
-[[component]]
-id = "pet"
+[[trigger.http]]
+route = "/pet/..."
+component = "pet"
+
+[component.pet]
 source = "Fermyon.PetStore.Pet/bin/Release/net8.0/Fermyon.PetStore.Pet.wasm"
 files = [{ source = "Fermyon.PetStore.Pet/assets", destination = "/assets" }]
-[component.config]
+allowed_outbound_hosts = ["http://localhost:3000", "postgres://localhost:5432"]
+[component.pet.variables]
 pg_conn_str = "{{ pg_conn_str }}"
-[component.build]
+[component.pet.build]
 command = "dotnet build -c Release"
 workdir = "Fermyon.PetStore.Pet"
-[component.trigger]
-route = "/pet/..."
 
-[[component]]
-id = "toys"
+[[trigger.http]]
+route = "/toys"
+component = "toys"
+
+[component.toys]
 source = "Fermyon.PetStore.Toys/bin/Release/net8.0/Fermyon.PetStore.Toys.wasm"
 files = [{ source = "Fermyon.PetStore.Toys/assets", destination = "/assets" }]
-[component.config]
+allowed_outbound_hosts = ["http://localhost:3000", "postgres://localhost:5432"]
+[component.toys.variables]
 pg_conn_str = "{{ pg_conn_str }}"
-[component.build]
+[component.toys.build]
 command = "dotnet build -c Release"
 workdir = "Fermyon.PetStore.Toys"
-[component.trigger]
-route = "/toys"
 
-[[component]]
-id = "new_toy"
+[[trigger.http]]
+route = "/toys/new"
+component = "new-toy"
+
+[component.new-toy]
 source = "Fermyon.PetStore.NewToy/bin/Release/net8.0/Fermyon.PetStore.NewToy.wasm"
 files = [{ source = "Fermyon.PetStore.NewToy/assets", destination = "/assets" }]
-[component.config]
+allowed_outbound_hosts = ["http://localhost:3000", "postgres://localhost:5432"]
+[component.new-toy.variables]
 pg_conn_str = "{{ pg_conn_str }}"
-[component.build]
+[component.new-toy.build]
 command = "dotnet build -c Release"
 workdir = "Fermyon.PetStore.NewToy"
-[component.trigger]
-route = "/toys/new"
 
-[[component]]
-id = "toy"
+[[trigger.http]]
+route = "/toy/..."
+component = "toy"
+
+[component.toy]
 source = "Fermyon.PetStore.Toy/bin/Release/net8.0/Fermyon.PetStore.Toy.wasm"
 files = [{ source = "Fermyon.PetStore.Toy/assets", destination = "/assets" }]
-[component.config]
+allowed_outbound_hosts = ["http://localhost:3000", "postgres://localhost:5432"]
+[component.toy.variables]
 pg_conn_str = "{{ pg_conn_str }}"
-[component.build]
+[component.toy.build]
 command = "dotnet build -c Release"
 workdir = "Fermyon.PetStore.Toy"
-[component.trigger]
-route = "/toy/..."

--- a/samples/hello-world/Handler.cs
+++ b/samples/hello-world/Handler.cs
@@ -27,7 +27,7 @@ public static class Handler
         var onboundRequest = new HttpRequest
         {
             Method = Fermyon.Spin.Sdk.HttpMethod.Delete,
-            Url = "http://127.0.0.1:3001/testingtesting?thing=otherthing",
+            Url = "http://127.0.0.1:3000/testingtesting?thing=otherthing",
             Headers = HttpKeyValues.FromDictionary(new Dictionary<string, string>
             {
                 { "X-Outbound-Test", "From .NET" },

--- a/samples/hello-world/spin.toml
+++ b/samples/hello-world/spin.toml
@@ -1,21 +1,32 @@
-spin_manifest_version = "1"
+spin_manifest_version = 2
+
+[application]
 name = "dotnet-hello"
-trigger = { type = "http", base = "/" }
 version = "1.0.0"
 
-[variables]
-defaulted = { default = "test value" }
-required = { required = true }
+[variables.defaulted]
+default = "test value"
 
-[[component]]
-id = "hello"
+[variables.required]
+required = true
+
+[[trigger.http]]
+route = "/..."
+component = "hello"
+
+[component.hello]
 source = "bin/Release/net8.0/HelloWorld.Spin.wasm"
-allowed_http_hosts = [ "https://spin.fermyon.dev", "http://127.0.0.1:3001" ]
+allowed_outbound_hosts = [
+  # http requests to this same app
+  "http://127.0.0.1:3000",
+  # requests to postgres
+  "postgres://127.0.0.1:5432",
+  # requests to redis
+  "redis://127.0.0.1:6379"
+]
 files = [{ source = "assets", destination = "/assets" }]
-[component.config]
+[component.hello.variables]
 defaulted = "{{ defaulted }}"
 required = "{{ required }}"
-[component.build]
+[component.hello.build]
 command = "dotnet build -c Release"
-[component.trigger]
-route = "/..."

--- a/templates/http-csharp/content/spin.toml
+++ b/templates/http-csharp/content/spin.toml
@@ -1,14 +1,16 @@
-spin_manifest_version = "1"
+spin_manifest_version = 2
+
+[application]
 authors = ["{{authors}}"]
 description = "{{project-description}}"
 name = "{{project-name}}"
 version = "1.0.0"
-trigger = { type = "http", base = "{{http-base}}" }
 
-[[component]]
-id = "{{project-name | snake_case}}"
-source = "bin/Release/net8.0/{{project-name | dotted_pascal_case}}.wasm"
-[component.build]
-command = "dotnet build -c Release"
-[component.trigger]
+[[trigger.http]]
 route = "{{http-path}}"
+component = "{{project-name | kebab_case}}"
+
+[component.{{project-name | kebab_case}}]
+source = "bin/Release/net8.0/{{project-name | dotted_pascal_case}}.wasm"
+[component.{{project-name | kebab_case}}.build]
+command = "dotnet build -c Release"

--- a/templates/http-csharp/metadata/spin-template.toml
+++ b/templates/http-csharp/metadata/spin-template.toml
@@ -4,5 +4,4 @@ description = "HTTP request handler using C# (EXPERIMENTAL)"
 
 [parameters]
 project-description = { type = "string", prompt = "Project description", default = "" }
-http-base = { type = "string", prompt = "HTTP base", default = "/", pattern = "^/\\S*$" }
 http-path = { type = "string", prompt = "HTTP path", default = "/...", pattern = "^/\\S*$" }


### PR DESCRIPTION
Updates apps under `samples` and `templates` to use the [Spin manifest v2 syntax](https://github.com/fermyon/spin/blob/main/docs/content/sips/005-manifest-redesign.md).

Note: I experienced some errors when running the [Fermyon.PetStore sample](https://github.com/fermyon/spin-dotnet-sdk/tree/main/samples/Fermyon.PetStore), but this also occurred on main.  We may want to track this in another issue.  Hoping one of the reviewers can compare notes here...

~~Also currently blocked on https://github.com/fermyon/spin-dotnet-sdk/issues/53; the template currently relies on the dotted_pascal_case filter.~~

_Assuming this is otherwise ready to go, it should wait until on/after the Spin 2.0 release.  Putting in Draft for now, but initial reviews appreciated._