### PR TITLE
chore(dotnet): Updated projects to use .NET 8.0

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -96,7 +96,7 @@ Your `spin.toml` file should reference the compiled Wasm file built from the pro
 ```toml
 [[component]]
 id = "test"
-source = "bin/Release/net7.0/MyApplication.wasm"
+source = "bin/Release/net8.0/MyApplication.wasm"
 [component.trigger]
 route = "/..."
 ```

--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,7 @@ An experimental SDK for building Spin application components using .NET.
 You'll need the following to build Spin applications using this SDK:
 
 - [Spin](https://spin.fermyon.dev) v0.5.0 or above
-- [.NET 7+](https://dotnet.microsoft.com/en-us/download/dotnet/7.0)
+- [.NET 8+](https://dotnet.microsoft.com/en-us/download/dotnet/8.0)
 - [Wizer](https://github.com/bytecodealliance/wizer/releases) - download and place it on your PATH
   - If you have Rust installed, you can install Wizer by running `make bootstrap` in the root of the SDK repo
 

--- a/samples/Fermyon.PetStore/Fermyon.PetStore.Common/Fermyon.PetStore.Common.csproj
+++ b/samples/Fermyon.PetStore/Fermyon.PetStore.Common/Fermyon.PetStore.Common.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/samples/Fermyon.PetStore/Fermyon.PetStore.Home/Project.csproj
+++ b/samples/Fermyon.PetStore/Fermyon.PetStore.Home/Project.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>Fermyon.PetStore.Home</AssemblyName>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/samples/Fermyon.PetStore/Fermyon.PetStore.NewPet/Project.csproj
+++ b/samples/Fermyon.PetStore/Fermyon.PetStore.NewPet/Project.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>Fermyon.PetStore.NewPet</AssemblyName>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/samples/Fermyon.PetStore/Fermyon.PetStore.NewToy/Project.csproj
+++ b/samples/Fermyon.PetStore/Fermyon.PetStore.NewToy/Project.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>Fermyon.PetStore.NewToy</AssemblyName>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/samples/Fermyon.PetStore/Fermyon.PetStore.Pet/Project.csproj
+++ b/samples/Fermyon.PetStore/Fermyon.PetStore.Pet/Project.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>preview</LangVersion>
     <AssemblyName>Fermyon.PetStore.Pet</AssemblyName>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/samples/Fermyon.PetStore/Fermyon.PetStore.Pets/Project.csproj
+++ b/samples/Fermyon.PetStore/Fermyon.PetStore.Pets/Project.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>Fermyon.PetStore.Pets</AssemblyName>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/samples/Fermyon.PetStore/Fermyon.PetStore.Toy/Project.csproj
+++ b/samples/Fermyon.PetStore/Fermyon.PetStore.Toy/Project.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>preview</LangVersion>
     <AssemblyName>Fermyon.PetStore.Toy</AssemblyName>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/samples/Fermyon.PetStore/Fermyon.PetStore.Toys/Project.csproj
+++ b/samples/Fermyon.PetStore/Fermyon.PetStore.Toys/Project.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>Fermyon.PetStore.Toys</AssemblyName>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/samples/Fermyon.PetStore/spin.toml
+++ b/samples/Fermyon.PetStore/spin.toml
@@ -10,7 +10,7 @@ pg_conn_str = { required = true }
 
 [[component]]
 id = "home"
-source = "Fermyon.PetStore.Home/bin/Release/net7.0/Fermyon.PetStore.Home.wasm"
+source = "Fermyon.PetStore.Home/bin/Release/net8.0/Fermyon.PetStore.Home.wasm"
 files = [{ source = "Fermyon.PetStore.Home/assets", destination = "/assets" }]
 [component.build]
 command = "dotnet build -c Release"
@@ -20,7 +20,7 @@ route = "/"
 
 [[component]]
 id = "pets"
-source = "Fermyon.PetStore.Pets/bin/Release/net7.0/Fermyon.PetStore.Pets.wasm"
+source = "Fermyon.PetStore.Pets/bin/Release/net8.0/Fermyon.PetStore.Pets.wasm"
 files = [{ source = "Fermyon.PetStore.Pets/assets", destination = "/assets" }]
 [component.config]
 pg_conn_str = "{{ pg_conn_str }}"
@@ -32,7 +32,7 @@ route = "/pets"
 
 [[component]]
 id = "new_pet"
-source = "Fermyon.PetStore.NewPet/bin/Release/net7.0/Fermyon.PetStore.NewPet.wasm"
+source = "Fermyon.PetStore.NewPet/bin/Release/net8.0/Fermyon.PetStore.NewPet.wasm"
 files = [{ source = "Fermyon.PetStore.NewPet/assets", destination = "/assets" }]
 [component.config]
 pg_conn_str = "{{ pg_conn_str }}"
@@ -44,7 +44,7 @@ route = "/pets/new"
 
 [[component]]
 id = "pet"
-source = "Fermyon.PetStore.Pet/bin/Release/net7.0/Fermyon.PetStore.Pet.wasm"
+source = "Fermyon.PetStore.Pet/bin/Release/net8.0/Fermyon.PetStore.Pet.wasm"
 files = [{ source = "Fermyon.PetStore.Pet/assets", destination = "/assets" }]
 [component.config]
 pg_conn_str = "{{ pg_conn_str }}"
@@ -56,7 +56,7 @@ route = "/pet/..."
 
 [[component]]
 id = "toys"
-source = "Fermyon.PetStore.Toys/bin/Release/net7.0/Fermyon.PetStore.Toys.wasm"
+source = "Fermyon.PetStore.Toys/bin/Release/net8.0/Fermyon.PetStore.Toys.wasm"
 files = [{ source = "Fermyon.PetStore.Toys/assets", destination = "/assets" }]
 [component.config]
 pg_conn_str = "{{ pg_conn_str }}"
@@ -68,7 +68,7 @@ route = "/toys"
 
 [[component]]
 id = "new_toy"
-source = "Fermyon.PetStore.NewToy/bin/Release/net7.0/Fermyon.PetStore.NewToy.wasm"
+source = "Fermyon.PetStore.NewToy/bin/Release/net8.0/Fermyon.PetStore.NewToy.wasm"
 files = [{ source = "Fermyon.PetStore.NewToy/assets", destination = "/assets" }]
 [component.config]
 pg_conn_str = "{{ pg_conn_str }}"
@@ -80,7 +80,7 @@ route = "/toys/new"
 
 [[component]]
 id = "toy"
-source = "Fermyon.PetStore.Toy/bin/Release/net7.0/Fermyon.PetStore.Toy.wasm"
+source = "Fermyon.PetStore.Toy/bin/Release/net8.0/Fermyon.PetStore.Toy.wasm"
 files = [{ source = "Fermyon.PetStore.Toy/assets", destination = "/assets" }]
 [component.config]
 pg_conn_str = "{{ pg_conn_str }}"

--- a/samples/hello-world/HelloWorld.Spin.csproj
+++ b/samples/hello-world/HelloWorld.Spin.csproj
@@ -5,7 +5,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>hello_world</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/samples/hello-world/spin.toml
+++ b/samples/hello-world/spin.toml
@@ -9,7 +9,7 @@ required = { required = true }
 
 [[component]]
 id = "hello"
-source = "bin/Release/net7.0/HelloWorld.Spin.wasm"
+source = "bin/Release/net8.0/HelloWorld.Spin.wasm"
 allowed_http_hosts = [ "https://spin.fermyon.dev", "http://127.0.0.1:3001" ]
 files = [{ source = "assets", destination = "/assets" }]
 [component.config]

--- a/src/Fermyon.Spin.Sdk.csproj
+++ b/src/Fermyon.Spin.Sdk.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/templates/http-csharp/content/Project.csproj
+++ b/templates/http-csharp/content/Project.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>{{project-name | dotted_pascal_case}}</AssemblyName>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/templates/http-csharp/content/spin.toml
+++ b/templates/http-csharp/content/spin.toml
@@ -7,7 +7,7 @@ trigger = { type = "http", base = "{{http-base}}" }
 
 [[component]]
 id = "{{project-name | snake_case}}"
-source = "bin/Release/net7.0/{{project-name | dotted_pascal_case}}.wasm"
+source = "bin/Release/net8.0/{{project-name | dotted_pascal_case}}.wasm"
 [component.build]
 command = "dotnet build -c Release"
 [component.trigger]


### PR DESCRIPTION
Updated projects under src, samples and templates folders to use .NET 8.0 instead of 7.0.

The motivation for this change came from no longer wanting to change both the .csproj and .toml files when creating a project from the csharp template (https://github.com/fermyon/spin-dotnet-sdk)